### PR TITLE
Drop license family

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ test:
 about:
   home: https://github.com/twolfson/restructuredtext-lint
   license: Unlicense
-  license_family: Public Domain
   license_file: UNLICENSE
   summary: 'Lint reStructuredText files'
   dev_url: https://github.com/twolfson/restructuredtext-lint


### PR DESCRIPTION
It appears newer `conda-build` version have issues with the `license_family`, particularly if it is Public Domain. So just drop it.

Note: This is causing issues for the team update script. Snippet of the failure below. Also here is the [log]( https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/214372866 ). Though I may restart this build later so it may vanish, hence the snippet.

<details>

```
...
Checking restructuredtext_lint
Traceback (most recent call last):
  File "/home/travis/build/conda-forge/conda-forge.github.io/scripts/update_teams.py", line 79, in <module>
    meta = MetaData(os.path.dirname(recipe))
  File "/home/travis/conda/tmp_envs/3efe971f26cd635a9c0c/lib/python2.7/site-packages/conda_build/metadata.py", line 437, in __init__
    self.parse_again(config=config, permit_undefined_jinja=True)
  File "/home/travis/conda/tmp_envs/3efe971f26cd635a9c0c/lib/python2.7/site-packages/conda_build/metadata.py", line 470, in parse_again
    config=config, path=self.meta_path)
  File "/home/travis/conda/tmp_envs/3efe971f26cd635a9c0c/lib/python2.7/site-packages/conda_build/metadata.py", line 199, in parse
    ensure_valid_license_family(res)
  File "/home/travis/conda/tmp_envs/3efe971f26cd635a9c0c/lib/python2.7/site-packages/conda_build/license_family.py", line 106, in ensure_valid_license_family
    (license_family, comma_join(sorted(allowed_license_families)))))
RuntimeError: about/license_family 'Public Domain' not allowed. Allowed families are
AGPL, APACHE, BSD, GPL, GPL2, GPL3, LGPL, MIT, NONE, OTHER,
PROPRIETARY, PSF, and PUBLIC-DOMAIN.
CalledProcessError: Command '['python', '/home/travis/build/conda-forge/conda-forge.github.io/scripts/update_teams.py', './feedstocks_repo/feedstocks']' returned non-zero exit status 1.
WARNING conda-execute:execute_within_env(121): CalledProcessError: Command '['python', '/home/travis/build/conda-forge/conda-forge.github.io/scripts/update_teams.py', './feedstocks_repo/feedstocks']' returned non-zero exit status 1.
Could not find execution log for /home/travis/conda/tmp_envs/2a27113fa4461a4a6460. Removing environment.
WARNING conda-tmpenv:cleanup_tmp_envs(216): Could not find execution log for /home/travis/conda/tmp_envs/2a27113fa4461a4a6460. Removing environment.
```

</details>
<br>

xref: https://github.com/conda/conda-build/issues/1856 (though I thought there was an older issue too 😕)

\<rant\>
We need to move team updates to a web service so we don't need to fix all recipes to run one script.

xref: https://github.com/conda-forge/conda-forge-webservices/issues/63
\</rant\>